### PR TITLE
feat(ntv): ✨ listen copy by keyboard

### DIFF
--- a/packages/NarrativeTextVis/docs/export.zh-CN.md
+++ b/packages/NarrativeTextVis/docs/export.zh-CN.md
@@ -15,6 +15,8 @@ nav:
 
 `TextExporter` 默认参数与 `PluginManager` 一致，可通过制定 plugin descriptor 中的 getText 定义复制行为。
 
+同时，通过 `onCopyByKeyboard` 可以监听文本范围刷选复制的事件。
+
 ```jsx
 import React from 'react';
 import { Space, Button, message } from 'antd';
@@ -55,7 +57,12 @@ export default () => {
           }}
         >复制带正号的文本</Button>
       </Space>
-      <NarrativeTextVis spec={booking} />
+      <NarrativeTextVis 
+        spec={booking} 
+        onCopyByKeyboard={() => {
+          message.info('通过 Ctrl+C 复制成功');
+        }} 
+      />
     </>
   )
 }

--- a/packages/NarrativeTextVis/package.json
+++ b/packages/NarrativeTextVis/package.json
@@ -41,6 +41,7 @@
   "devDependencies": {
     "@types/enzyme": "^3.10.9",
     "@types/jest": "^26.0.24",
+    "@types/is-hotkey": "^0.1.7",
     "@types/lodash": "^4.14.180",
     "@types/react": "^17.0.15",
     "@types/react-dom": "^17.0.9",
@@ -59,6 +60,7 @@
   },
   "dependencies": {
     "@antv/narrative-text-schema": "^0.3.4",
+    "is-hotkey": "^0.2.0",
     "lodash": "^4.17.21",
     "styled-components": "^5.3.5",
     "uuid": "^8.3.2"

--- a/packages/NarrativeTextVis/src/utils/elementContainsSelection.ts
+++ b/packages/NarrativeTextVis/src/utils/elementContainsSelection.ts
@@ -1,0 +1,33 @@
+function isOrContains(node: Node | null, container: HTMLElement) {
+  while (node) {
+    if (node === container) {
+      return true;
+    }
+    // eslint-disable-next-line no-param-reassign
+    node = node.parentNode;
+  }
+  return false;
+}
+/**
+ * 判断选区是否在指定元素内
+ */
+export function elementContainsSelection(el: HTMLElement) {
+  let sel: Selection | null;
+  if (window.getSelection) {
+    sel = window.getSelection();
+    if (sel?.rangeCount > 0) {
+      for (let i = 0; i < sel?.rangeCount; i += 1) {
+        if (!isOrContains(sel?.getRangeAt(i)?.commonAncestorContainer, el)) {
+          return false;
+        }
+      }
+      return true;
+    }
+    // @ts-ignore
+    // eslint-disable-next-line no-cond-assign
+  } else if ((sel = document?.selection) && sel?.type !== 'Control') {
+    // @ts-ignore
+    return isOrContains(sel?.createRange()?.parentElement(), el);
+  }
+  return false;
+}

--- a/packages/NarrativeTextVis/src/utils/index.ts
+++ b/packages/NarrativeTextVis/src/utils/index.ts
@@ -1,3 +1,4 @@
 export { getPrefixCls } from './getPrefixCls';
 export { classnames } from './classnames';
 export { functionalize } from './functionalize';
+export { elementContainsSelection } from './elementContainsSelection';


### PR DESCRIPTION
- 支持传入 props 事件监听用户在 narrative 内的键盘刷选复制行为；
- 修复 Phrase 组件的类型；
- 自定义 Phrase events 触发；