### PR TITLE
feat(ntv): ✨ update design

### DIFF
--- a/packages/NarrativeTextVis/src/chore/plugin/presets/createCompare.tsx
+++ b/packages/NarrativeTextVis/src/chore/plugin/presets/createCompare.tsx
@@ -4,9 +4,7 @@ import { ArrowDown, ArrowUp } from '../../../assets/icons';
 import { createEntityPhraseFactory } from '../createEntityPhraseFactory';
 import { SpecificEntityPhraseDescriptor } from '../plugin-protocol.type';
 import { getPrefixCls } from '../../../utils';
-
-const ENTITY_NEG_COLOR = '#30bf78';
-const ENTITY_POS_COLOR = '#f4664a';
+import { seedToken } from '../../../theme';
 
 const defaultDeltaValueDescriptor: SpecificEntityPhraseDescriptor = {
   encoding: {
@@ -32,8 +30,8 @@ export const createRatioValue = createEntityPhraseFactory('ratio_value', default
 
 function getCompareColor(assessment: ValueAssessment) {
   let color;
-  if (assessment === 'positive') color = ENTITY_POS_COLOR;
-  if (assessment === 'negative') color = ENTITY_NEG_COLOR;
+  if (assessment === 'positive') color = seedToken.colorPositive;
+  if (assessment === 'negative') color = seedToken.colorNegative;
   return color;
 }
 

--- a/packages/NarrativeTextVis/src/chore/plugin/presets/createContributeRatio.tsx
+++ b/packages/NarrativeTextVis/src/chore/plugin/presets/createContributeRatio.tsx
@@ -1,11 +1,10 @@
 import { createEntityPhraseFactory } from '../createEntityPhraseFactory';
 import { SpecificEntityPhraseDescriptor } from '../plugin-protocol.type';
-
-export const ENTITY_CONTRIB_COLOR = '#722ed1';
+import { seedToken } from '../../../theme';
 
 const defaultContributeRatioDescriptor: SpecificEntityPhraseDescriptor = {
   encoding: {
-    color: ENTITY_CONTRIB_COLOR,
+    color: seedToken.colorConclusion,
   },
 };
 

--- a/packages/NarrativeTextVis/src/chore/plugin/presets/createDimensionValue.tsx
+++ b/packages/NarrativeTextVis/src/chore/plugin/presets/createDimensionValue.tsx
@@ -1,9 +1,10 @@
 import { createEntityPhraseFactory } from '../createEntityPhraseFactory';
 import { SpecificEntityPhraseDescriptor } from '../plugin-protocol.type';
+import { seedToken } from '../../../theme';
 
 const defaultDimensionValueDescriptor: SpecificEntityPhraseDescriptor = {
   encoding: {
-    underline: true,
+    color: seedToken.colorDimensionValue,
   },
 };
 

--- a/packages/NarrativeTextVis/src/chore/plugin/presets/createMetricName.tsx
+++ b/packages/NarrativeTextVis/src/chore/plugin/presets/createMetricName.tsx
@@ -1,9 +1,11 @@
 import { createEntityPhraseFactory } from '../createEntityPhraseFactory';
 import { SpecificEntityPhraseDescriptor } from '../plugin-protocol.type';
+import { seedToken } from '../../../theme';
 
 const defaultMetricNameDescriptor: SpecificEntityPhraseDescriptor = {
   encoding: {
-    fontWeight: 'bold',
+    fontWeight: 500,
+    color: seedToken.colorMetricName,
   },
 };
 

--- a/packages/NarrativeTextVis/src/chore/plugin/presets/createMetricValue.tsx
+++ b/packages/NarrativeTextVis/src/chore/plugin/presets/createMetricValue.tsx
@@ -1,11 +1,10 @@
 import { createEntityPhraseFactory } from '../createEntityPhraseFactory';
 import { SpecificEntityPhraseDescriptor } from '../plugin-protocol.type';
-
-const ENTITY_VALUE_COLOR = '#2797fe';
+import { seedToken } from '../../../theme';
 
 const defaultMetricValueDescriptor: SpecificEntityPhraseDescriptor = {
   encoding: {
-    color: ENTITY_VALUE_COLOR,
+    color: seedToken.colorMetricValue,
   },
 };
 

--- a/packages/NarrativeTextVis/src/chore/plugin/presets/createOtherMetricValue.tsx
+++ b/packages/NarrativeTextVis/src/chore/plugin/presets/createOtherMetricValue.tsx
@@ -1,9 +1,11 @@
 import { createEntityPhraseFactory } from '../createEntityPhraseFactory';
 import { SpecificEntityPhraseDescriptor } from '../plugin-protocol.type';
+import { seedToken } from '../../../theme';
 
 const defaultOtherMetricValueDescriptor: SpecificEntityPhraseDescriptor = {
   encoding: {
     fontWeight: 'bold',
+    color: seedToken.colorOtherValue,
   },
 };
 

--- a/packages/NarrativeTextVis/src/chore/plugin/presets/createTimeDesc.tsx
+++ b/packages/NarrativeTextVis/src/chore/plugin/presets/createTimeDesc.tsx
@@ -1,9 +1,10 @@
 import { createEntityPhraseFactory } from '../createEntityPhraseFactory';
 import { SpecificEntityPhraseDescriptor } from '../plugin-protocol.type';
+import { seedToken } from '../../../theme';
 
 const defaultTimeDescDescriptor: SpecificEntityPhraseDescriptor = {
   encoding: {
-    underline: true,
+    color: seedToken.colorDimensionValue,
   },
 };
 

--- a/packages/NarrativeTextVis/src/chore/plugin/presets/createTrendDesc.tsx
+++ b/packages/NarrativeTextVis/src/chore/plugin/presets/createTrendDesc.tsx
@@ -3,9 +3,11 @@ import { isArray } from 'lodash';
 import { SingleLineChart } from '../../../line-charts';
 import { createEntityPhraseFactory } from '../createEntityPhraseFactory';
 import { SpecificEntityPhraseDescriptor } from '../plugin-protocol.type';
+import { seedToken } from '../../../theme';
 
 const defaultTrendDescDescriptor: SpecificEntityPhraseDescriptor = {
   encoding: {
+    color: seedToken.colorConclusion,
     inlineChart: (value, { detail }) => {
       if (isArray(detail) && detail.length) return <SingleLineChart data={detail} />;
       return null;

--- a/packages/NarrativeTextVis/src/index.ts
+++ b/packages/NarrativeTextVis/src/index.ts
@@ -9,3 +9,4 @@ export * as NStyledComponents from './styled';
 export * from '@antv/narrative-text-schema';
 export * from './chore/plugin';
 export * from './chore/exporter';
+export { seedToken } from './theme';

--- a/packages/NarrativeTextVis/src/styled/bullet.tsx
+++ b/packages/NarrativeTextVis/src/styled/bullet.tsx
@@ -1,12 +1,12 @@
 import styled from 'styled-components';
-import { DEFAULT_FONT_COLOR, DEFAULT_FONT_SIZE, SMALL_FONT_SIZE } from './constants';
-import { ThemeProps } from '../interface';
+import { seedToken } from '../theme';
+import type { ThemeProps } from '../interface';
 
 export const Bullet = styled.div<ThemeProps>`
   padding-left: 16px;
   font-family: PingFangSC, sans-serif;
-  color: ${DEFAULT_FONT_COLOR};
-  font-size: ${({ size = 'normal' }) => (size === 'small' ? SMALL_FONT_SIZE : DEFAULT_FONT_SIZE)};
+  color: ${seedToken.colorBase};
+  font-size: ${({ size = 'normal' }) => (size === 'small' ? seedToken.fontSizeSmall : seedToken.fontSizeBase)};
   margin-bottom: 4px;
 `;
 

--- a/packages/NarrativeTextVis/src/styled/constants.tsx
+++ b/packages/NarrativeTextVis/src/styled/constants.tsx
@@ -1,3 +1,0 @@
-export const DEFAULT_FONT_SIZE = '14px';
-export const SMALL_FONT_SIZE = '12px';
-export const DEFAULT_FONT_COLOR = '#262626';

--- a/packages/NarrativeTextVis/src/styled/container.tsx
+++ b/packages/NarrativeTextVis/src/styled/container.tsx
@@ -1,9 +1,9 @@
 import styled from 'styled-components';
-import { DEFAULT_FONT_COLOR, DEFAULT_FONT_SIZE, SMALL_FONT_SIZE } from './constants';
-import { ThemeProps } from '../interface';
+import { seedToken } from '../theme';
+import type { ThemeProps } from '../interface';
 
 export const Container = styled.div<ThemeProps>`
   font-family: PingFangSC, sans-serif;
-  color: ${DEFAULT_FONT_COLOR};
-  font-size: ${({ size = 'normal' }) => (size === 'small' ? SMALL_FONT_SIZE : DEFAULT_FONT_SIZE)};
+  color: ${seedToken.colorBase};
+  font-size: ${({ size = 'normal' }) => (size === 'small' ? seedToken.fontSizeSmall : seedToken.fontSizeBase)};
 `;

--- a/packages/NarrativeTextVis/src/styled/entity.tsx
+++ b/packages/NarrativeTextVis/src/styled/entity.tsx
@@ -1,15 +1,15 @@
 import styled from 'styled-components';
 import { ThemeProps } from '../interface';
-import { DEFAULT_FONT_SIZE, SMALL_FONT_SIZE } from './constants';
+import { seedToken } from '../theme';
 
 export const Entity = styled.span<ThemeProps>`
   display: flex;
   display: inline-block;
   align-items: center;
   box-sizing: border-box;
-  font-size: ${({ size = 'normal' }) => (size === 'small' ? SMALL_FONT_SIZE : DEFAULT_FONT_SIZE)};
+  font-size: ${({ size = 'normal' }) => (size === 'small' ? seedToken.fontSizeSmall : seedToken.fontSizeBase)};
   font-family: Roboto-Medium, sans-serif;
   line-height: 1.5em;
   border-radius: 2px;
-  color: '#404040';
+  color: ${seedToken.colorEntityBase};
 `;

--- a/packages/NarrativeTextVis/src/styled/paragraph.tsx
+++ b/packages/NarrativeTextVis/src/styled/paragraph.tsx
@@ -1,11 +1,11 @@
 import styled from 'styled-components';
-import { DEFAULT_FONT_COLOR, DEFAULT_FONT_SIZE, SMALL_FONT_SIZE } from './constants';
-import { ThemeProps } from '../interface';
+import { seedToken } from '../theme';
+import type { ThemeProps } from '../interface';
 
 export const P = styled.p<ThemeProps>`
   font-family: PingFangSC, sans-serif;
-  color: ${DEFAULT_FONT_COLOR};
-  font-size: ${({ size = 'normal' }) => (size === 'small' ? SMALL_FONT_SIZE : DEFAULT_FONT_SIZE)};
+  color: ${seedToken.colorBase};
+  font-size: ${({ size = 'normal' }) => (size === 'small' ? seedToken.fontSizeSmall : seedToken.fontSizeBase)};
   min-height: 24px;
   line-height: 24px;
   margin-bottom: 4px;

--- a/packages/NarrativeTextVis/src/theme/index.ts
+++ b/packages/NarrativeTextVis/src/theme/index.ts
@@ -1,0 +1,1 @@
+export { seedToken } from './seed';

--- a/packages/NarrativeTextVis/src/theme/seed.ts
+++ b/packages/NarrativeTextVis/src/theme/seed.ts
@@ -1,0 +1,14 @@
+export const seedToken = {
+  colorBase: 'rgba(0, 0, 0, 0.65)',
+  colorEntityBase: '#404040',
+  colorPositive: '#FA541C',
+  colorNegative: '#13A8A8',
+  colorConclusion: '#030852',
+  colorDimensionValue: '#391085',
+  colorMetricName: 'rgba(0, 0, 0, 0.88)',
+  colorMetricValue: '#1677FF',
+  colorOtherValue: '#1677FF',
+
+  fontSizeBase: 14,
+  fontSizeSmall: 12,
+} as const;


### PR DESCRIPTION
RT，更新 ntv 设计规范，当前效果：https://bbsqq.github.io/antv-t8-site/narrative/intro

TODOs:
1. **是否整理 entity type？** 比如 time_desc 和 dim_value 目前对设计规范来说同为维值、贡献度和趋势表述均为结论 -- 暂时不做 BC，待整理交互控件时一起归类；
2. 类似 design token 实现，更灵活定制主题样式；-- 待技术方案设计；