### PR TITLE
fix(ntv): 🐛 plugin type

### DIFF
--- a/packages/NarrativeTextVis/src/chore/plugin/PluginManager.ts
+++ b/packages/NarrativeTextVis/src/chore/plugin/PluginManager.ts
@@ -3,7 +3,6 @@ import { isArray } from 'lodash';
 import {
   PhraseDescriptor,
   BlockDescriptor,
-  AnyObject,
   PluginType,
   isBlockDescriptor,
   isEntityDescriptor,
@@ -13,8 +12,8 @@ import { presetPlugins } from './presets';
 
 export class PluginManager {
   protected entities: Partial<Record<EntityType, PhraseDescriptor<EntityMetaData>>> = {};
-  protected customPhrases: Record<string, PhraseDescriptor<AnyObject>> = {};
-  protected customBlocks: Record<string, BlockDescriptor<AnyObject>> = {};
+  protected customPhrases: Record<string, PhraseDescriptor<any>> = {};
+  protected customBlocks: Record<string, BlockDescriptor<any>> = {};
   constructor(plugins?: PluginType[]) {
     this.registerAll(getPlugins(plugins));
   }

--- a/packages/NarrativeTextVis/src/chore/plugin/createCustomBlockFactory.ts
+++ b/packages/NarrativeTextVis/src/chore/plugin/createCustomBlockFactory.ts
@@ -1,7 +1,7 @@
-import { AnyObject, BlockDescriptor } from './plugin-protocol.type';
+import { BlockDescriptor } from './plugin-protocol.type';
 
-export const createCustomBlockFactory = <MetaData = AnyObject>(
-  descriptor: Omit<BlockDescriptor<MetaData>, 'isBlock'>,
-): BlockDescriptor<MetaData> => {
+export const createCustomBlockFactory = <CustomBlockSpec = any>(
+  descriptor: Omit<BlockDescriptor<CustomBlockSpec>, 'isBlock'>,
+): BlockDescriptor<CustomBlockSpec> => {
   return { ...descriptor, isBlock: true };
 };

--- a/packages/NarrativeTextVis/src/chore/plugin/createCustomPhraseFactory.ts
+++ b/packages/NarrativeTextVis/src/chore/plugin/createCustomPhraseFactory.ts
@@ -1,6 +1,6 @@
-import { PhraseDescriptor, CustomPhraseDescriptor, AnyObject } from './plugin-protocol.type';
+import { PhraseDescriptor, CustomPhraseDescriptor } from './plugin-protocol.type';
 import { createPhraseFactory } from './createPhraseFactory';
 
-export const createCustomPhraseFactory = <MetaData = AnyObject>(
+export const createCustomPhraseFactory = <MetaData = any>(
   descriptor: Omit<CustomPhraseDescriptor<MetaData>, 'isEntity'>,
 ): PhraseDescriptor<MetaData> => createPhraseFactory(false)<MetaData>(descriptor);

--- a/packages/NarrativeTextVis/src/chore/plugin/plugin-protocol.type.ts
+++ b/packages/NarrativeTextVis/src/chore/plugin/plugin-protocol.type.ts
@@ -52,28 +52,28 @@ export type EntityPhrasePlugin = (
   mode?: CustomEntityMode,
 ) => PhraseDescriptor<EntityMetaData>;
 
-export interface BlockDescriptor<MetaData> {
+export interface BlockDescriptor<CustomBlockSpec> {
   key: string;
   isBlock: true;
-  className?: string | ((metadata: MetaData) => string);
-  style?: CSSProperties | ((metadata: MetaData) => CSSProperties);
-  render?: (metadata: MetaData) => ReactNode;
-  getText?: (metadata: MetaData) => string;
-  getMarkdown?: (metadata: MetaData) => string;
+  className?: string | ((spec: CustomBlockSpec) => string);
+  style?: CSSProperties | ((spec: CustomBlockSpec) => CSSProperties);
+  render?: (spec: CustomBlockSpec) => ReactNode;
+  getText?: (spec: CustomBlockSpec) => string;
+  getMarkdown?: (spec: CustomBlockSpec) => string;
 }
 
 export type AnyObject = Record<string, unknown>;
 
-export type PluginType = PhraseDescriptor<AnyObject> | BlockDescriptor<AnyObject>;
+export type PluginType = PhraseDescriptor<any> | BlockDescriptor<any>;
 
-export function isBlockDescriptor(plugin: PluginType): plugin is BlockDescriptor<AnyObject> {
+export function isBlockDescriptor(plugin: PluginType): plugin is BlockDescriptor<any> {
   return 'isBlock' in plugin && plugin.isBlock;
 }
 
-export function isEntityDescriptor(plugin: PluginType): plugin is PhraseDescriptor<AnyObject> {
+export function isEntityDescriptor(plugin: PluginType): plugin is PhraseDescriptor<any> {
   return 'isEntity' in plugin && plugin.isEntity;
 }
 
-export function isCustomPhraseDescriptor(plugin: PluginType): plugin is PhraseDescriptor<AnyObject> {
+export function isCustomPhraseDescriptor(plugin: PluginType): plugin is PhraseDescriptor<any> {
   return 'isEntity' in plugin && !plugin.isEntity;
 }

--- a/packages/NarrativeTextVis/src/phrases/Phrase.tsx
+++ b/packages/NarrativeTextVis/src/phrases/Phrase.tsx
@@ -10,7 +10,7 @@ import { isFunction, kebabCase, isEmpty } from 'lodash';
 import { Entity, Bold, Italic, Underline } from '../styled';
 import { getPrefixCls, classnames as cx, functionalize } from '../utils';
 import { ThemeProps, ExtensionProps, PhraseEvents } from '../interface';
-import { PhraseDescriptor, AnyObject, presetPluginManager } from '../chore/plugin';
+import { PhraseDescriptor, presetPluginManager } from '../chore/plugin';
 
 type PhraseProps = ThemeProps &
   ExtensionProps &
@@ -20,7 +20,7 @@ type PhraseProps = ThemeProps &
 
 function renderPhraseByDescriptor(
   spec: EntityPhraseSpec | CustomPhraseSpec,
-  descriptor: PhraseDescriptor<AnyObject>,
+  descriptor: PhraseDescriptor<any>,
   theme: ThemeProps,
   events: PhraseEvents,
 ) {


### PR DESCRIPTION
- PluginType 内泛型改为 any；
- custom block 内泛型名称明确为 spec；

```ts
cosnt plugin1: Phrase<{ a: number }> = {
    // ...
}

type PluginType = Phrase<AnyObject>
const plugins: PluginType[] = [
	plugin1,
  	plugin2
]
```

因为plugin1里明确了 类型含 a 但是 AnyObject 并不能约束必须含 a，所以在 PluginTypep[] 处报错了。
