### PR TITLE
feat(ntv): ✨ number phrase show origin as tooltip

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "@types/jest": "^26.0.24",
     "@typescript-eslint/eslint-plugin": "^4.28.5",
     "@typescript-eslint/parser": "^4.28.5",
-    "antd": "^4.19.5",
+    "antd": "^4.24.1",
     "babel-jest": "^27.5.1",
     "babel-plugin-import": "^1.13.5",
     "concurrently": "^6.2.0",

--- a/packages/NarrativeTextEditor/package.json
+++ b/packages/NarrativeTextEditor/package.json
@@ -47,7 +47,7 @@
     "@types/react": "^17.0.15",
     "@types/react-dom": "^17.0.9",
     "@types/styled-components": "^5.1.24",
-    "antd": "^4.19.3",
+    "antd": "^4.24.1",
     "jest": "^27.0.6",
     "jest-environment-jsdom": "^27.2.5",
     "npm-run-all": "^4.1.5",

--- a/packages/NarrativeTextEditor/src/plugins/variable/index.tsx
+++ b/packages/NarrativeTextEditor/src/plugins/variable/index.tsx
@@ -17,4 +17,4 @@ export const variableComponents = {
 
 export { VariableCombobox } from './VariableCombobox';
 export { ELEMENT_VARIABLE, ELEMENT_VARIABLE_INPUT } from './constants';
-export { VariableNodeData, VariableComboboxItem, VariableNode } from './types';
+export type { VariableNodeData, VariableComboboxItem, VariableNode } from './types';

--- a/packages/NarrativeTextVis/docs/mock/booking.json
+++ b/packages/NarrativeTextVis/docs/mock/booking.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "../../../narrative-text-schema/build/text-schema.json",
   "sections": [
     {
       "paragraphs": [
@@ -32,7 +33,8 @@
               "type": "entity",
               "value": "$348k",
               "metadata": {
-                "entityType": "metric_value"
+                "entityType": "metric_value",
+                "origin": 348.12
               }
             },
             {

--- a/packages/NarrativeTextVis/docs/style.zh-CN.md
+++ b/packages/NarrativeTextVis/docs/style.zh-CN.md
@@ -96,9 +96,10 @@ export default () => (
         <Phrase
           spec={{
             type: 'entity',
-            value: '901632.11',
+            value: '90.1w',
             metadata: {
               entityType: 'metric_value',
+              origin: 901632.11,
             },
           }}
         />
@@ -110,6 +111,7 @@ export default () => (
             value: '30%',
             metadata: {
               entityType: 'other_metric_value',
+              origin: 0.30012,
             },
           }}
         />
@@ -123,6 +125,7 @@ export default () => (
               entityType: 'delta_value',
               assessment: 'positive',
               detail: ['120.12', '220.45'],
+              origin: 100.33456,
             },
           }}
         />
@@ -135,6 +138,7 @@ export default () => (
             metadata: {
               entityType: 'ratio_value',
               assessment: 'negative',
+              origin: 0.30012,
             },
           }}
         />
@@ -146,6 +150,7 @@ export default () => (
             value: '20%',
             metadata: {
               entityType: 'contribute_ratio',
+              origin: 0.2000077,
             },
           }}
         />
@@ -199,6 +204,7 @@ export default () => (
             value: '30%',
             metadata: {
               entityType: 'proportion',
+              origin: 0.30012,
             },
           }}
         />

--- a/packages/NarrativeTextVis/package.json
+++ b/packages/NarrativeTextVis/package.json
@@ -48,6 +48,7 @@
     "@types/styled-components": "^5.1.25",
     "@types/uuid": "^8.3.1",
     "@wojtekmaj/enzyme-adapter-react-17": "^0.6.3",
+    "antd": "^4.24.1",
     "enzyme": "^3.11.0",
     "jest": "^27.0.6",
     "jest-environment-jsdom": "^27.2.5",
@@ -67,6 +68,7 @@
     "uuid": "^8.3.2"
   },
   "peerDependencies": {
+    "antd": ">=4.16.13",
     "react": ">=16.9.0",
     "react-dom": ">=16.9.0"
   }

--- a/packages/NarrativeTextVis/src/chore/plugin/plugin-protocol.type.ts
+++ b/packages/NarrativeTextVis/src/chore/plugin/plugin-protocol.type.ts
@@ -1,5 +1,6 @@
-import { CSSProperties, ReactNode } from 'react';
-import { EntityMetaData, EntityEncoding, EntityType } from '@antv/narrative-text-schema';
+import type { CSSProperties, ReactNode } from 'react';
+import type { TooltipProps } from 'antd';
+import type { EntityMetaData, EntityEncoding, EntityType } from '@antv/narrative-text-schema';
 
 /**
  * description for phrase render
@@ -14,6 +15,15 @@ export interface PhraseDescriptor<MetaData> {
    * @param metadata phrase spec metadata
    */
   content?: (value: string, metadata: MetaData) => ReactNode;
+  /**
+   * tooltip of phrases
+   */
+  tooltip?:
+    | false
+    | (TooltipProps & {
+        // overwrite antd tooltip title props
+        title: (value: string, metadata: MetaData) => ReactNode;
+      });
   classNames?: string[] | ((value: string, metadata: MetaData) => string[]);
   style?: CSSProperties | ((value: string, metadata: MetaData) => CSSProperties);
   onHover?: (value: string, metadata: MetaData) => string;

--- a/packages/NarrativeTextVis/src/chore/plugin/presets/createCompare.tsx
+++ b/packages/NarrativeTextVis/src/chore/plugin/presets/createCompare.tsx
@@ -13,6 +13,9 @@ const defaultDeltaValueDescriptor: SpecificEntityPhraseDescriptor = {
   },
   classNames: (value, { assessment }) => [getPrefixCls(`value-${assessment}`)],
   getText: getAssessmentText,
+  tooltip: {
+    title: (value, metadata) => metadata.origin ?? `${metadata.origin}`,
+  },
 };
 
 export const createDeltaValue = createEntityPhraseFactory('delta_value', defaultDeltaValueDescriptor);
@@ -24,6 +27,9 @@ const defaultRatioValueDescriptor: SpecificEntityPhraseDescriptor = {
   },
   classNames: (value, { assessment }) => [getPrefixCls(`value-${assessment}`)],
   getText: getAssessmentText,
+  tooltip: {
+    title: (value, metadata) => metadata.origin ?? `${metadata.origin}`,
+  },
 };
 
 export const createRatioValue = createEntityPhraseFactory('ratio_value', defaultRatioValueDescriptor);

--- a/packages/NarrativeTextVis/src/chore/plugin/presets/createContributeRatio.tsx
+++ b/packages/NarrativeTextVis/src/chore/plugin/presets/createContributeRatio.tsx
@@ -6,6 +6,9 @@ const defaultContributeRatioDescriptor: SpecificEntityPhraseDescriptor = {
   encoding: {
     color: seedToken.colorConclusion,
   },
+  tooltip: {
+    title: (value, metadata) => metadata.origin ?? `${metadata.origin}`,
+  },
 };
 
 export const createContributeRatio = createEntityPhraseFactory('contribute_ratio', defaultContributeRatioDescriptor);

--- a/packages/NarrativeTextVis/src/chore/plugin/presets/createDimensionValue.tsx
+++ b/packages/NarrativeTextVis/src/chore/plugin/presets/createDimensionValue.tsx
@@ -6,6 +6,7 @@ const defaultDimensionValueDescriptor: SpecificEntityPhraseDescriptor = {
   encoding: {
     color: seedToken.colorDimensionValue,
   },
+  tooltip: false,
 };
 
 export const createDimensionValue = createEntityPhraseFactory('dim_value', defaultDimensionValueDescriptor);

--- a/packages/NarrativeTextVis/src/chore/plugin/presets/createMetricName.tsx
+++ b/packages/NarrativeTextVis/src/chore/plugin/presets/createMetricName.tsx
@@ -7,6 +7,7 @@ const defaultMetricNameDescriptor: SpecificEntityPhraseDescriptor = {
     fontWeight: 500,
     color: seedToken.colorMetricName,
   },
+  tooltip: false,
 };
 
 export const createMetricName = createEntityPhraseFactory('metric_name', defaultMetricNameDescriptor);

--- a/packages/NarrativeTextVis/src/chore/plugin/presets/createMetricValue.tsx
+++ b/packages/NarrativeTextVis/src/chore/plugin/presets/createMetricValue.tsx
@@ -6,6 +6,9 @@ const defaultMetricValueDescriptor: SpecificEntityPhraseDescriptor = {
   encoding: {
     color: seedToken.colorMetricValue,
   },
+  tooltip: {
+    title: (value, metadata) => metadata.origin ?? `${metadata.origin}`,
+  },
 };
 
 export const createMetricValue = createEntityPhraseFactory('metric_value', defaultMetricValueDescriptor);

--- a/packages/NarrativeTextVis/src/chore/plugin/presets/createOtherMetricValue.tsx
+++ b/packages/NarrativeTextVis/src/chore/plugin/presets/createOtherMetricValue.tsx
@@ -7,6 +7,9 @@ const defaultOtherMetricValueDescriptor: SpecificEntityPhraseDescriptor = {
     fontWeight: 'bold',
     color: seedToken.colorOtherValue,
   },
+  tooltip: {
+    title: (value, metadata) => metadata.origin ?? `${metadata.origin}`,
+  },
 };
 
 export const createOtherMetricValue = createEntityPhraseFactory(

--- a/packages/NarrativeTextVis/src/chore/plugin/presets/createProportion.tsx
+++ b/packages/NarrativeTextVis/src/chore/plugin/presets/createProportion.tsx
@@ -7,6 +7,9 @@ const defaultProportionDescriptor: SpecificEntityPhraseDescriptor = {
   encoding: {
     inlineChart: (value, { origin }) => <ProportionChart data={getProportionNumber(value, origin as number)} />,
   },
+  tooltip: {
+    title: (value, metadata) => metadata.origin ?? `${metadata.origin}`,
+  },
 };
 
 export const createProportion = createEntityPhraseFactory('proportion', defaultProportionDescriptor);

--- a/packages/NarrativeTextVis/src/chore/plugin/presets/createTimeDesc.tsx
+++ b/packages/NarrativeTextVis/src/chore/plugin/presets/createTimeDesc.tsx
@@ -6,6 +6,7 @@ const defaultTimeDescDescriptor: SpecificEntityPhraseDescriptor = {
   encoding: {
     color: seedToken.colorDimensionValue,
   },
+  tooltip: false,
 };
 
 export const createTimeDesc = createEntityPhraseFactory('time_desc', defaultTimeDescDescriptor);

--- a/packages/NarrativeTextVis/src/chore/plugin/presets/createTrendDesc.tsx
+++ b/packages/NarrativeTextVis/src/chore/plugin/presets/createTrendDesc.tsx
@@ -13,6 +13,7 @@ const defaultTrendDescDescriptor: SpecificEntityPhraseDescriptor = {
       return null;
     },
   },
+  tooltip: false,
 };
 
 export const createTrendDesc = createEntityPhraseFactory('trend_desc', defaultTrendDescDescriptor);

--- a/packages/NarrativeTextVis/src/phrases/Phrase.tsx
+++ b/packages/NarrativeTextVis/src/phrases/Phrase.tsx
@@ -1,4 +1,5 @@
 import React, { ReactNode } from 'react';
+import { Tooltip } from 'antd';
 import {
   PhraseSpec,
   EntityPhraseSpec,
@@ -25,7 +26,15 @@ function renderPhraseByDescriptor(
   events: PhraseEvents,
 ) {
   const { value = '', metadata = {}, styles: specStyles = {} } = spec;
-  const { overwrite, classNames, style: descriptorStyle, onHover, onClick, content = () => value } = descriptor || {};
+  const {
+    overwrite,
+    classNames,
+    style: descriptorStyle,
+    onHover,
+    tooltip,
+    onClick,
+    content = () => value,
+  } = descriptor || {};
 
   const handleClick = () => {
     onClick?.(spec?.value, metadata);
@@ -59,12 +68,23 @@ function renderPhraseByDescriptor(
   if (isFunction(overwrite)) {
     defaultNode = overwrite(defaultNode, value, metadata);
   }
-  return !isEmpty(events) || isFunction(onClick) || isFunction(onHover) ? (
-    <span onClick={handleClick} onMouseEnter={handleMouseEnter} onMouseLeave={handleMouseLeave}>
-      {defaultNode}
-    </span>
+
+  const nodeWithEvents =
+    !isEmpty(events) || isFunction(onClick) || isFunction(onHover) ? (
+      <span onClick={handleClick} onMouseEnter={handleMouseEnter} onMouseLeave={handleMouseLeave}>
+        {defaultNode}
+      </span>
+    ) : (
+      defaultNode
+    );
+
+  const showTooltip = tooltip && tooltip?.title(value, metadata);
+  return showTooltip ? (
+    <Tooltip {...tooltip} title={showTooltip}>
+      {nodeWithEvents}
+    </Tooltip>
   ) : (
-    defaultNode
+    nodeWithEvents
   );
 }
 


### PR DESCRIPTION
数值型的短语默认将 metadata.origin 作为 tooltip 展示。包括：metric_value, delta_value, ratio_value, contribution, other_metric_value。

![image](https://user-images.githubusercontent.com/35586469/200238981-e1448b6b-13bd-4581-b947-248c4f5280a7.png)
