### PR TITLE
refactor: use arrow as ratio suffix

### DIFF
--- a/prompt.md
+++ b/prompt.md
@@ -40,18 +40,19 @@ Please write the article strictly according to the uploaded JSON Schema structur
 ### Entity label type (`entity_type` list)
 
 Below is a list of types supported by entity phrases. Please be sure to strictly mark entities according to the following table:
-| Type | Description | Example |
-| -------------------------------------------------------------------------------------------------------------------------------
-| `metric_name` | Indicator name | "Shipment", "Growth Rate" |
-| `metric_value` | Main indicator value | "146 million units", "120 factories" |
-| `other_metric_value` | Other metric values ​​| "$19.2 billion" |
-| `delta_value` | Difference | "+120" |
-| `ratio_value` | Rate | "+8.4%", "9%" |
-| `contribute_ratio` | Contribution | "40%" |
-| `trend_desc` | Trend Description | "Continuously Rising", "Stable" |
-| `dim_value` | Dimensional identification | "India", "Jiangsu", "Overseas Market" |
-| `time_value` | Time stamp | "Q3 2024", "all year" |
-| `proportion` | Proportion description | "30%" |
+
+| Type                 | Description                | Example                               |
+| -------------------- | -------------------------- | ------------------------------------- |
+| `metric_name`        | Indicator name             | "Shipment", "Growth Rate"             |
+| `metric_value`       | Main indicator value       | "146 million units", "120 factories"  |
+| `other_metric_value` | Other metric values        | "$19.2 billion"                       |
+| `delta_value`        | Difference                 | "+120"                                |
+| `ratio_value`        | Rate                       | "+8.4%", "9%"                         |
+| `contribute_ratio`   | Contribution               | "40%"                                 |
+| `trend_desc`         | Trend Description          | "Continuously Rising", "Stable"       |
+| `dim_value`          | Dimensional identification | "India", "Jiangsu", "Overseas Market" |
+| `time_value`         | Time stamp                 | "Q3 2024", "all year"                 |
+| `proportion`         | Proportion description     | "30%"                                 |
 
 When possible, it is required to use as much key information in the sentence as possible to replace ordinary `text` (such as indicators, values, time, numbers, etc.), to ensure the diversity of generated text and improve readability. (In particular, it is necessary to increase the frequency of usage of the phrases `delta_value`, `ratio_value`, `proportion`).
 

--- a/src/plugin/presets/createCompare.ts
+++ b/src/plugin/presets/createCompare.ts
@@ -1,4 +1,3 @@
-import { ComponentChildren } from 'preact';
 import { ValueAssessment, EntityMetaData } from '../../schema';
 // import { ArrowDown, ArrowUp } from '../../assets/icons';
 import { createEntityPhraseFactory } from '../createEntityPhraseFactory';
@@ -6,6 +5,8 @@ import { SpecificEntityPhraseDescriptor } from '../types';
 import { getPrefixCls, isNumber } from '../../utils';
 import { createDocumentFragment } from '../utils';
 import { SeedTokenOptions } from '../../theme';
+
+const MARGIN_RIGHT = 1;
 
 const defaultDeltaValueDescriptor: SpecificEntityPhraseDescriptor = {
   classNames: (value, { assessment }) => [getPrefixCls(`value-${assessment}`)],
@@ -27,7 +28,8 @@ const defaultRatioValueDescriptor: SpecificEntityPhraseDescriptor = {
   classNames: (value, { assessment }) => [getPrefixCls(`value-${assessment}`)],
   getText: getAssessmentText,
   render: (value, { assessment }) => {
-    return createDocumentFragment(getComparePrefix(assessment, ['-', '+']), value, 'prefix');
+    const prefix = getComparePrefix(assessment, [createArrow('up'), createArrow('down')]);
+    return createDocumentFragment(prefix as HTMLElement | string, value, 'prefix');
   },
   style: (value, { assessment }, themeSeedToken) => ({
     color: getCompareColor(assessment, themeSeedToken),
@@ -46,8 +48,11 @@ function getCompareColor(assessment: ValueAssessment, themeSeedToken: SeedTokenO
   return color;
 }
 
-function getComparePrefix(assessment: ValueAssessment, [neg, pos]: [ComponentChildren, ComponentChildren]): string {
-  let prefix = null;
+function getComparePrefix(
+  assessment: ValueAssessment,
+  [neg, pos]: [Element | string, Element | string],
+): Element | string {
+  let prefix: Element | string | null = null;
   if (assessment === 'negative') prefix = neg;
   if (assessment === 'positive') prefix = pos;
   return prefix;
@@ -55,4 +60,31 @@ function getComparePrefix(assessment: ValueAssessment, [neg, pos]: [ComponentChi
 
 function getAssessmentText(value: string, metadata: EntityMetaData) {
   return `${metadata?.assessment === 'negative' ? '-' : ''}${value}`;
+}
+
+function createArrow(direction: 'up' | 'down'): Element {
+  const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+  svg.setAttribute('width', '8px');
+  svg.setAttribute('height', '9px');
+  svg.setAttribute('viewBox', '0 0 8 9');
+  svg.style.marginRight = `${MARGIN_RIGHT}px`;
+  svg.setAttribute('version', '1.1');
+
+  const g = document.createElementNS('http://www.w3.org/2000/svg', 'g');
+  g.setAttribute('transform', 'translate(-2.000000, -2.000000)');
+
+  const polygon = document.createElementNS('http://www.w3.org/2000/svg', 'polygon');
+  polygon.setAttribute('fill', 'currentColor');
+
+  const points =
+    direction === 'down'
+      ? '6 2 9.5 11 2.5 11' // arrow down
+      : '6 11 9.5 2 2.5 2'; // arrow up
+
+  polygon.setAttribute('points', points);
+
+  g.appendChild(polygon);
+  svg.appendChild(g);
+
+  return svg;
 }

--- a/src/plugin/utils/createDocumentFragment.ts
+++ b/src/plugin/utils/createDocumentFragment.ts
@@ -7,7 +7,7 @@
  * use function `addElement` to add element to original element.
  */
 export const createDocumentFragment = (
-  element: HTMLElement | string | number,
+  element: string | number | Element,
   value: string,
   position: 'suffix' | 'prefix' = 'suffix',
 ): DocumentFragment => {
@@ -16,7 +16,7 @@ export const createDocumentFragment = (
   const originalElementSpan = value;
   fragment.textContent = originalElementSpan;
 
-  let newElement: HTMLElement | undefined = undefined;
+  let newElement: Element | undefined = undefined;
 
   if (typeof element === 'string' || typeof element === 'number') {
     newElement = document.createElement('span');

--- a/src/vis-components/styled/entity.ts
+++ b/src/vis-components/styled/entity.ts
@@ -11,6 +11,7 @@ const getEntityStyle = (theme: SeedTokenOptions) => {
     lineHeight: '1.5em',
     borderRadius: '2px',
     color: theme.colorEntityBase,
+    margin: '0 2px',
   };
 };
 


### PR DESCRIPTION
- 使用 arrow 作为 ratio value 的 suffix，效果图如下：

![image](https://github.com/user-attachments/assets/748b75f4-a52b-43eb-9a54-7b1b050e3152)
- 修复 prompt 的 entity table 格式错误