### PR TITLE
fix: ul、ol用html原生标签实现，在复制黏贴到笔记软件时可以保留列表的格式

### DIFF
--- a/__tests__/snapshot/text-simple.html
+++ b/__tests__/snapshot/text-simple.html
@@ -279,7 +279,7 @@
         </p>
       </div>
       <div>
-        <div
+        <ul
           as="ul"
           style="
             font-family: PingFangSC, sans-serif;
@@ -329,7 +329,7 @@
                 ><span><span>+</span>$50.6k</span></span
               ></span
             ><span>) </span><span>See all lead sources.</span>
-            <div
+            <ol
               as="ol"
               style="
                 font-family: PingFangSC, sans-serif;
@@ -343,7 +343,7 @@
             >
               <li style="list-style: inherit; line-height: 1.74" class="ntv-li">
                 <span>sub node 1</span>
-                <div
+                <ul
                   as="ul"
                   style="
                     font-family: PingFangSC, sans-serif;
@@ -416,12 +416,12 @@
                               ></path></svg></span></span></span
                     ></span>
                   </li>
-                </div>
+                </ul>
               </li>
               <li style="list-style: inherit; line-height: 1.74" class="ntv-li">
                 <span>sub node 2</span>
               </li>
-            </div>
+            </ol>
           </li>
           <li style="list-style: inherit; line-height: 1.74" class="ntv-li">
             <span class="ntv-tooltip-trigger"
@@ -500,7 +500,7 @@
               ></span
             ><span>) </span><span>See all opportunity types</span><span>.</span>
           </li>
-        </div>
+        </ul>
       </div>
       <div>
         <p

--- a/src/vis-components/styled/bullet.ts
+++ b/src/vis-components/styled/bullet.ts
@@ -23,7 +23,7 @@ export const Li = createStyledComponent({
 });
 
 export const Ol = createStyledComponent({
-  element: 'div',
+  element: 'ol',
   factoryStyles: (theme) => ({
     ...getBulletStyle(theme),
     listStyleType: 'decimal',
@@ -31,7 +31,7 @@ export const Ol = createStyledComponent({
 });
 
 export const Ul = createStyledComponent({
-  element: 'div',
+  element: 'ul',
   factoryStyles: (theme) => ({
     ...getBulletStyle(theme),
     listStyleType: 'disc',


### PR DESCRIPTION
ul、ol用html原生标签实现，在复制黏贴到笔记软件(比如notion时)时可以保留列表的格式，用div来实现在黏贴时会丢失列表的样式。